### PR TITLE
Fix inconsistent name of Chip Tier 1

### DIFF
--- a/Defs/RecipeDefs/Recipes_Items.xml
+++ b/Defs/RecipeDefs/Recipes_Items.xml
@@ -96,12 +96,12 @@
     <researchPrerequisite>PRF_CoreTierI</researchPrerequisite>
   </RecipeDef>
 
-  <!--==================================== Weak Chip ==============================-->
+  <!--==================================== Basic Chip (Chip Tier 1) ==============================-->
   <RecipeDef>
     <defName>MakePRF_ElectronicChip_I</defName>
-    <label>make weak AI chip</label>
-    <description>Make weak AI chip</description>
-    <jobString>Making weak AI chip</jobString>
+    <label>make basic AI chip</label>
+    <description>Make basic AI chip</description>
+    <jobString>Making basic AI chip</jobString>
     <workSpeedStat>GeneralLaborSpeed</workSpeedStat>
     <effectWorking>Cook</effectWorking>
     <soundWorking>Recipe_Machining</soundWorking>
@@ -143,7 +143,7 @@
     <researchPrerequisite>PRF_CoreTierII</researchPrerequisite>
   </RecipeDef>
 
-  <!--==================================== Advanced AI Core ==============================-->
+  <!--==================================== Advanced AI Core (Chip Tier 2) ==============================-->
   <RecipeDef>
     <defName>MakePRF_ElectronicChip_II</defName>
     <label>make Adv. AI core</label>
@@ -208,7 +208,7 @@
     <researchPrerequisite>PRF_CoreTierIII</researchPrerequisite>
   </RecipeDef>
 
-  <!--==================================== qubit processor ==============================-->
+  <!--==================================== qubit processor (Chip Tier 3) ==============================-->
   <RecipeDef>
     <defName>MakePRF_ElectronicChip_III</defName>
     <label>make qubit processor</label>


### PR DESCRIPTION
Also a bit of labeling.  Somebody contacted me about this wondering why the hell they couldn't progress to Tier 2.

Basic AI Chips are required for assembling the research bench, but in all the production recipes they're labeled as "Weak AI Chips" which is probably some kind of legacy holdover from a different name.  So as far as they could tell there was no way to make the thing they needed, because presumably "Basic" is better than "Weak", and they were under the assumption "Weak AI Chips" were some kind of Tier 0.5.